### PR TITLE
Use Arrow type for both input and output of `dora-ros2-bridge`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,8 @@ jobs:
       run: |
         source /opt/ros/humble/setup.bash && ros2 run turtlesim turtlesim_node &
         pip3 install -r ./examples/python-ros2-dataflow/requirements.txt
-        maturin develop -m python/Cargo.toml
+        maturin build -m python/Cargo.toml
+        pip install target/wheels/*.whl
         cargo run --example python-ros2-dataflow --features="ros2-examples"
     - name: "Python Standalone"
       timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
       run: |
         source /opt/ros/humble/setup.bash && ros2 run turtlesim turtlesim_node &
         pip3 install -r ./examples/python-ros2-dataflow/requirements.txt
+        maturin develop -m python/Cargo.toml
         cargo run --example python-ros2-dataflow --features="ros2-examples"
     - name: "Python Standalone"
       timeout-minutes: 30

--- a/examples/python-ros2-dataflow/control_node.py
+++ b/examples/python-ros2-dataflow/control_node.py
@@ -21,7 +21,7 @@ for i in range(500):
         node.send_output(
             "direction",
             pa.array(
-                [random.random() + 1, 0, 0, 0, 0, random.random() - 0.5],
+                [1, 0, 0, 0, 0, 1],
                 type=pa.uint8(),
             ),
         )

--- a/examples/python-ros2-dataflow/random_turtle.py
+++ b/examples/python-ros2-dataflow/random_turtle.py
@@ -37,7 +37,7 @@ for i in range(500):
                     }
 
                     print(direction, flush=True)
-                    twist_writer.publish(direction)
+                    twist_writer.publish(pa.array(direction))
                 case "tick":
                     pose = (
                         pose_reader.next()
@@ -46,6 +46,8 @@ for i in range(500):
                     if pose == None:
                         print("stop", flush=True)
                         continue
+
+                    pose = pose[0].as_py()
 
                     assert (
                         pose["x"] != 5.544445

--- a/examples/python-ros2-dataflow/random_turtle.py
+++ b/examples/python-ros2-dataflow/random_turtle.py
@@ -56,11 +56,12 @@ for i in range(500):
                         "turtle_pose",
                         pa.array(
                             [
-                                pose["x"],
-                                pose["y"],
-                                pose["theta"],
-                                pose["linear_velocity"],
-                                pose["angular_velocity"],
+                                # TODO: Replace with real value once `float32`` support from dora is published
+                                0,  # pose["x"],
+                                0,  # pose["y"],
+                                0,  # pose["theta"],
+                                0,  # pose["linear_velocity"],
+                                0,  # pose["angular_velocity"],
                             ],
                             type=pa.uint8(),
                         ),

--- a/examples/python-ros2-dataflow/requirements.txt
+++ b/examples/python-ros2-dataflow/requirements.txt
@@ -1,3 +1,3 @@
 pyarrow
 dora-rs
-dora-ros2-bridge
+maturin

--- a/examples/python-standalone-bridge/random_turtle.py
+++ b/examples/python-standalone-bridge/random_turtle.py
@@ -1,5 +1,6 @@
 from dora_ros2_bridge import *
 import time, random
+import pyarrow as pa
 
 context = Ros2Context()
 node = context.new_node("turtle_teleop", "/ros2_demo", Ros2NodeOptions(rosout=True))
@@ -23,10 +24,10 @@ for i in range(500):
             "z": (random.random() - 0.5) * 5,
         },
     }
-    twist_writer.publish(direction)
+    twist_writer.publish(pa.array([direction]))
     while True:
         pose = pose_reader.next()
         if pose == None:
             break
-        print(pose)
+        print(f"pose: {pose.to_pylist()}")
     time.sleep(0.5)

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -10,7 +10,6 @@ dora-ros2-bridge-msg-gen = { path = "../msg-gen" }
 pyo3 = { version = "0.19", features = ["eyre", "abi3-py37", "serde"] }
 eyre = "0.6"
 serde = "1.0.166"
-serde_yaml = "0.8.23"
 flume = "0.10.14"
 arrow = { version = "45.0.0", features = ["pyarrow"] }
 

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -7,13 +7,12 @@ edition = "2021"
 [dependencies]
 dora-ros2-bridge = { path = "..", default-features = false }
 dora-ros2-bridge-msg-gen = { path = "../msg-gen" }
-pyo3 = { version = "0.18", features = ["eyre", "abi3-py37", "serde"] }
+pyo3 = { version = "0.19", features = ["eyre", "abi3-py37", "serde"] }
 eyre = "0.6"
 serde = "1.0.166"
 serde_yaml = "0.8.23"
 flume = "0.10.14"
-arrow = { version = "35.0.0", features = ["pyarrow"] }
-pythonize = "0.18.0"
+arrow = { version = "45.0.0", features = ["pyarrow"] }
 
 [lib]
 name = "dora_ros2_bridge"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "dora-ros2-bridge"
+dependencies = ['pyarrow']
 
 [tool.maturin]
 features = ["pyo3/extension-module"]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -187,7 +187,7 @@ impl Ros2Publisher {
         //// and map types need to be serialized differently)
         let typed_value = TypedValue {
             value: &value,
-            type_info: self.type_info.clone(),
+            type_info: &self.type_info,
         };
 
         self.publisher

--- a/python/src/typed/mod.rs
+++ b/python/src/typed/mod.rs
@@ -1,38 +1,58 @@
-use arrow::datatypes::{DataType, Field};
+use arrow::{
+    array::{
+        make_array, Array, ArrayData, BooleanArray, Float32Array, Float64Array, Int16Array,
+        Int32Array, Int64Array, Int8Array, StringArray, StructArray, UInt16Array, UInt32Array,
+        UInt64Array, UInt8Array,
+    },
+    datatypes::{DataType, Field},
+};
 use dora_ros2_bridge_msg_gen::types::{
     primitives::{BasicType, NestableType},
     MemberType, Message,
 };
-use eyre::{Context, ContextCompat};
-use std::collections::HashMap;
+use eyre::{Context, ContextCompat, Result};
+use std::{collections::HashMap, sync::Arc};
 
 pub use serialize::TypedValue;
 
 pub mod deserialize;
 pub mod serialize;
 
-    pub fn for_message(
-        messages: &HashMap<String, HashMap<String, Message>>,
-        package_name: &str,
-        message_name: &str,
-) -> eyre::Result<DataType> {
-        let empty = HashMap::new();
-        let package_messages = messages.get(package_name).unwrap_or(&empty);
-        let message = package_messages
-            .get(message_name)
-            .context("unknown type name")?;
-    let fields = message
-                .members
-                .iter()
-                .map(|m| {
-            Result::<_, eyre::Report>::Ok(Field::new(
-                m.name.clone(),
-                type_info_for_member(m, package_name, messages)?,
-                true, // default: default_for_member(m, package_name, messages)?,
+#[derive(Debug, Clone, PartialEq)]
+pub struct TypeInfo {
+    fields: DataType,
+    defaults: ArrayData,
+}
+
+pub fn for_message(
+    messages: &HashMap<String, HashMap<String, Message>>,
+    package_name: &str,
+    message_name: &str,
+) -> eyre::Result<TypeInfo> {
+    let empty = HashMap::new();
+    let package_messages = messages.get(package_name).unwrap_or(&empty);
+    let message = package_messages
+        .get(message_name)
+        .context("unknown type name")?;
+    let default_struct_vec: Vec<(Arc<Field>, Arc<dyn Array>)> = message
+        .members
+        .iter()
+        .map(|m| {
+            Result::<_, eyre::Report>::Ok((
+                Arc::new(Field::new(
+                    m.name.clone(),
+                    type_info_for_member(m, package_name, messages)?,
+                    false,
+                )),
+                make_array(default_for_member(m, package_name, messages)?),
             ))
         })
         .collect::<Result<_, _>>()?;
-    Ok(DataType::Struct(fields))
+    let default_struct: StructArray = default_struct_vec.into();
+    Ok(TypeInfo {
+        fields: default_struct.data_type().clone(),
+        defaults: default_struct.into(),
+    })
 }
 
 fn type_info_for_member(
@@ -63,9 +83,9 @@ fn type_info_for_member(
                 let referenced_message = package_messages
                     .get(&name.0)
                     .context("unknown referenced message")?;
-                for_message(messages, package_name, &referenced_message.name)?
+                for_message(messages, package_name, &referenced_message.name)?.fields
             }
-            NestableType::NamespacedType(t) => for_message(messages, &t.package, &t.name)?,
+            NestableType::NamespacedType(t) => for_message(messages, &t.package, &t.name)?.fields,
             NestableType::GenericString(_) => DataType::Utf8,
         },
         MemberType::Array(array) => match array.value_type {
@@ -76,7 +96,7 @@ fn type_info_for_member(
                 let referenced_message = package_messages
                     .get(&name.0)
                     .context("unknown referenced message")?;
-                for_message(messages, package_name, &referenced_message.name)?
+                for_message(messages, package_name, &referenced_message.name)?.fields
             }
             _ => todo!(),
         },
@@ -86,28 +106,28 @@ fn type_info_for_member(
     })
 }
 
-fn default_for_member(
+pub fn default_for_member(
     m: &dora_ros2_bridge_msg_gen::types::Member,
     package_name: &str,
     messages: &HashMap<String, HashMap<String, Message>>,
-) -> eyre::Result<Option<serde_yaml::Value>> {
+) -> eyre::Result<ArrayData> {
     let empty = HashMap::new();
     let package_messages = messages.get(package_name).unwrap_or(&empty);
 
     let value = match &m.r#type {
         MemberType::NestableType(t) => match t {
-            t @ NestableType::BasicType(_) | t @ NestableType::GenericString(_) => {
-                match &m.default.as_deref() {
-                    Some([]) => eyre::bail!("empty default value not supported"),
-                    Some([default]) => serde_yaml::from_str(default).with_context(|| {
-                        format!("failed to parse default value for `{}`", m.name)
-                    })?,
-                    Some(_) => eyre::bail!(
-                        "there should be only a single default value for non-sequence types"
-                    ),
-                    None => default_for_basic_type(t),
-                }
-            }
+            t @ NestableType::BasicType(_) | t @ NestableType::GenericString(_) => match &m
+                .default
+                .as_deref()
+            {
+                Some([]) => eyre::bail!("empty default value not supported"),
+                Some([default]) => preset_default_for_basic_type(t, &default)
+                    .with_context(|| format!("failed to parse default value for `{}`", m.name))?,
+                Some(_) => eyre::bail!(
+                    "there should be only a single default value for non-sequence types"
+                ),
+                None => default_for_basic_type(t),
+            },
             NestableType::NamedType(name) => {
                 if m.default.is_some() {
                     eyre::bail!("default values for nested types are not supported")
@@ -127,56 +147,110 @@ fn default_for_member(
                 default_for_referenced_message(referenced_message, &t.package, messages)?
             }
         },
-        MemberType::Array(_) | MemberType::Sequence(_) | MemberType::BoundedSequence(_) => m
-            .default
-            .as_ref()
-            .map(|default| {
-                Result::<_, eyre::Report>::Ok(serde_yaml::Value::Sequence(
-                    default
-                        .iter()
-                        .map(|v| serde_yaml::from_str(v))
-                        .collect::<Result<_, _>>()?,
-                ))
-            })
-            .transpose()?,
+        MemberType::Array(_) | MemberType::Sequence(_) | MemberType::BoundedSequence(_) => {
+            todo!()
+        }
     };
     Ok(value)
 }
 
-fn default_for_basic_type(t: &NestableType) -> Option<serde_yaml::Value> {
+fn default_for_basic_type(t: &NestableType) -> ArrayData {
     match t {
         NestableType::BasicType(t) => match t {
-            BasicType::I8
-            | BasicType::I16
-            | BasicType::I32
-            | BasicType::I64
-            | BasicType::U8
-            | BasicType::U16
-            | BasicType::U32
-            | BasicType::U64
-            | BasicType::F32
-            | BasicType::F64
-            | BasicType::Char
-            | BasicType::Byte => Some(serde_yaml::Value::Number(0u32.into())),
-            BasicType::Bool => Some(serde_yaml::Value::Bool(false)),
+            BasicType::I8 => Int8Array::from(vec![0]).into(),
+            BasicType::I16 => Int16Array::from(vec![0]).into(),
+            BasicType::I32 => Int32Array::from(vec![0]).into(),
+            BasicType::I64 => Int64Array::from(vec![0]).into(),
+            BasicType::U8 => UInt8Array::from(vec![0]).into(),
+            BasicType::U16 => UInt16Array::from(vec![0]).into(),
+            BasicType::U32 => UInt32Array::from(vec![0]).into(),
+            BasicType::U64 => UInt64Array::from(vec![0]).into(),
+            BasicType::F32 => Float32Array::from(vec![0.]).into(),
+            BasicType::F64 => Float64Array::from(vec![0.]).into(),
+            BasicType::Char => StringArray::from(vec![""]).into(),
+            BasicType::Byte => UInt8Array::from(vec![] as Vec<u8>).into(),
+            BasicType::Bool => BooleanArray::from(vec![false]).into(),
         },
-        NestableType::GenericString(_) => Some(serde_yaml::Value::String(String::new())),
-        _ => None,
+        NestableType::GenericString(_) => StringArray::from(vec![""]).into(),
+        _ => todo!(),
     }
+}
+fn preset_default_for_basic_type(t: &NestableType, preset: &str) -> Result<ArrayData> {
+    Ok(match t {
+        NestableType::BasicType(t) => match t {
+            BasicType::I8 => Int8Array::from(vec![preset
+                .parse::<i8>()
+                .context("Could not parse preset default value")?])
+            .into(),
+            BasicType::I16 => Int16Array::from(vec![preset
+                .parse::<i16>()
+                .context("Could not parse preset default value")?])
+            .into(),
+            BasicType::I32 => Int32Array::from(vec![preset
+                .parse::<i32>()
+                .context("Could not parse preset default value")?])
+            .into(),
+            BasicType::I64 => Int64Array::from(vec![preset
+                .parse::<i64>()
+                .context("Could not parse preset default value")?])
+            .into(),
+            BasicType::U8 => UInt8Array::from(vec![preset
+                .parse::<u8>()
+                .context("Could not parse preset default value")?])
+            .into(),
+            BasicType::U16 => UInt16Array::from(vec![preset
+                .parse::<u16>()
+                .context("Could not parse preset default value")?])
+            .into(),
+            BasicType::U32 => UInt32Array::from(vec![preset
+                .parse::<u32>()
+                .context("Could not parse preset default value")?])
+            .into(),
+            BasicType::U64 => UInt64Array::from(vec![preset
+                .parse::<u64>()
+                .context("Could not parse preset default value")?])
+            .into(),
+            BasicType::F32 => Float32Array::from(vec![preset
+                .parse::<f32>()
+                .context("Could not parse preset default value")?])
+            .into(),
+            BasicType::F64 => Float64Array::from(vec![preset
+                .parse::<f64>()
+                .context("Could not parse preset default value")?])
+            .into(),
+            BasicType::Char => StringArray::from(vec![preset]).into(),
+            BasicType::Byte => UInt8Array::from(preset.as_bytes().to_owned()).into(),
+            BasicType::Bool => BooleanArray::from(vec![preset
+                .parse::<bool>()
+                .context("could not parse preset default value")?])
+            .into(),
+        },
+        NestableType::GenericString(_) => StringArray::from(vec![preset]).into(),
+        _ => todo!(),
+    })
 }
 
 fn default_for_referenced_message(
     referenced_message: &Message,
     package_name: &str,
     messages: &HashMap<String, HashMap<String, Message>>,
-) -> eyre::Result<Option<serde_yaml::Value>> {
-    let mapping: Option<_> = referenced_message
+) -> eyre::Result<ArrayData> {
+    let fields: Vec<(Arc<Field>, Arc<dyn Array>)> = referenced_message
         .members
         .iter()
         .map(|m| {
             let default = default_for_member(m, package_name, messages)?;
-            Ok(default.map(|d| (serde_yaml::Value::String(m.name.clone()), d)))
+            Result::<_, eyre::Report>::Ok((
+                Arc::new(Field::new(
+                    m.name.clone(),
+                    default.data_type().clone(),
+                    false,
+                )),
+                make_array(default),
+            ))
         })
-        .collect::<Result<_, eyre::Report>>()?;
-    Ok(mapping.map(serde_yaml::Value::Mapping))
+        .collect::<Result<_, _>>()?;
+
+    let struct_array: StructArray = fields.into();
+    Ok(struct_array.into())
 }

--- a/python/src/typed/serialize.rs
+++ b/python/src/typed/serialize.rs
@@ -12,7 +12,7 @@ use super::TypeInfo;
 #[derive(Debug, Clone, PartialEq)]
 pub struct TypedValue<'a> {
     pub value: &'a ArrayData,
-    pub type_info: TypeInfo,
+    pub type_info: &'a TypeInfo,
 }
 
 impl serde::Serialize for TypedValue<'_> {
@@ -77,7 +77,7 @@ impl serde::Serialize for TypedValue<'_> {
                             DUMMY_FIELD_NAME,
                             &TypedValue {
                                 value: &field_value,
-                                type_info: TypeInfo {
+                                type_info: &TypeInfo {
                                     fields: field.data_type().clone(),
                                     defaults: default,
                                 },

--- a/python/src/typed/serialize.rs
+++ b/python/src/typed/serialize.rs
@@ -1,10 +1,15 @@
 use super::TypeInfo;
-use eyre::{Context, ContextCompat};
+use arrow::array::ArrayData;
+use arrow::array::Float32Array;
+use arrow::array::Float64Array;
+use arrow::array::Int32Array;
+use arrow::array::StringArray;
+use arrow::array::StructArray;
 use serde::ser::SerializeStruct;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct TypedValue<'a> {
-    pub value: &'a serde_yaml::Value,
+    pub value: &'a ArrayData,
     pub type_info: &'a TypeInfo,
 }
 
@@ -15,30 +20,26 @@ impl serde::Serialize for TypedValue<'_> {
     {
         match &self.type_info {
             TypeInfo::I32 => {
-                let number = self
-                    .value
-                    .as_i64()
-                    .context("expected i32 value")
-                    .and_then(|n| i32::try_from(n).context("value too large"))
-                    .map_err(serde::ser::Error::custom)?;
+                let int_array: Int32Array = self.value.clone().into();
+                let number = int_array.value(0);
                 serializer.serialize_i32(number)
             }
             TypeInfo::F32 => {
-                let number = self
-                    .value
-                    .as_f64()
-                    .context("expected f32 value")
-                    .map_err(serde::ser::Error::custom)? as f32;
+                let int_array: Float32Array = self.value.clone().into();
+                let number = int_array.value(0);
                 serializer.serialize_f32(number)
             }
             TypeInfo::F64 => {
-                let number = self
-                    .value
-                    .as_f64()
-                    .context("expected f64 value")
-                    .map_err(serde::ser::Error::custom)?;
+                let int_array: Float64Array = self.value.clone().into();
+                let number = int_array.value(0);
                 serializer.serialize_f64(number)
             }
+            TypeInfo::String => {
+                let int_array: StringArray = self.value.clone().into();
+                let string = int_array.value(0);
+                serializer.serialize_str(string)
+            }
+            TypeInfo::Array(basic_type) => todo!(),
             TypeInfo::Struct { name: _, fields } => {
                 /// Serde requires that struct and field names are known at
                 /// compile time with a `'static` lifetime, which is not

--- a/python/src/typed/serialize.rs
+++ b/python/src/typed/serialize.rs
@@ -1,16 +1,15 @@
-use super::TypeInfo;
 use arrow::array::ArrayData;
 use arrow::array::Float32Array;
 use arrow::array::Float64Array;
 use arrow::array::Int32Array;
 use arrow::array::StringArray;
 use arrow::array::StructArray;
+use arrow::datatypes::DataType;
 use serde::ser::SerializeStruct;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct TypedValue<'a> {
     pub value: &'a ArrayData,
-    pub type_info: &'a TypeInfo,
 }
 
 impl serde::Serialize for TypedValue<'_> {
@@ -18,29 +17,29 @@ impl serde::Serialize for TypedValue<'_> {
     where
         S: serde::Serializer,
     {
-        match &self.type_info {
-            TypeInfo::I32 => {
+        match &self.value.data_type() {
+            DataType::Int32 => {
                 let int_array: Int32Array = self.value.clone().into();
                 let number = int_array.value(0);
                 serializer.serialize_i32(number)
             }
-            TypeInfo::F32 => {
+            DataType::Float32 => {
                 let int_array: Float32Array = self.value.clone().into();
                 let number = int_array.value(0);
                 serializer.serialize_f32(number)
             }
-            TypeInfo::F64 => {
+            DataType::Float64 => {
                 let int_array: Float64Array = self.value.clone().into();
                 let number = int_array.value(0);
                 serializer.serialize_f64(number)
             }
-            TypeInfo::String => {
+            DataType::Utf8 => {
                 let int_array: StringArray = self.value.clone().into();
                 let string = int_array.value(0);
                 serializer.serialize_str(string)
             }
-            TypeInfo::Array(basic_type) => todo!(),
-            TypeInfo::Struct { name: _, fields } => {
+            DataType::List(_field_ref) => todo!(),
+            DataType::Struct(fields) => {
                 /// Serde requires that struct and field names are known at
                 /// compile time with a `'static` lifetime, which is not
                 /// possible in this case. Thus, we need to use dummy names
@@ -53,29 +52,27 @@ impl serde::Serialize for TypedValue<'_> {
                 const DUMMY_FIELD_NAME: &str = "field";
 
                 let mut s = serializer.serialize_struct(DUMMY_STRUCT_NAME, fields.len())?;
+                let struct_array: StructArray = self.value.clone().into();
                 for field in fields {
-                    let field_value = match self.value.get(&field.name) {
+                    let field_value = match struct_array.column_by_name(field.name()) {
                         Some(value) => value,
-                        None => match &field.default {
-                            Some(default) => default,
                             None => {
                                 return Err(serde::ser::Error::custom(eyre::eyre!(
                                     "value has no field `{}`",
-                                    &field.name
+                                &field.name()
                                 )))
                             }
-                        },
                     };
                     s.serialize_field(
                         DUMMY_FIELD_NAME,
                         &TypedValue {
-                            value: field_value,
-                            type_info: &field.ty,
+                            value: &field_value.to_data(),
                         },
                     )?;
                 }
                 s.end()
             }
+            _ => todo!(),
         }
     }
 }


### PR DESCRIPTION
This PR replaces `serde-yaml` with `arrow`. This allows to have more flexibility with types as well as having a more coherent typing system for both `dora` and `dora-ros2-bridge`.

To do this, I have to:
- Replace `pythonize` into `arrow`. 
- Replace ser/de method to use arrow types instead of `serde-yaml` types. 
- Replace defaults mecanism as arrow typing does not have default value.

This should make further integration from dora-rs to dora-ros2-bridge easier as well as make supporting very specific type better. 